### PR TITLE
CI: drop the dead KAKIBOT_KEY SSH setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,7 @@ jobs:
       - uses: julia-actions/cache@d48542bb7b6239a9391789f01d21a6bdde9ad5df
       - run: julia --color=yes --project=.ci/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/cossio/CossioJuliaRegistry.git"))'
         shell: bash
-      - name: Setup SSH Keys and known_hosts
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.KAKIBOT_KEY }}"
       - uses: julia-actions/julia-buildpkg@90dd6f23eb49626e4e6612cb9d64d456f86e6a1c
         env:
           JULIA_PKG_USE_CLI_GIT: true
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       - uses: julia-actions/julia-runtest@79a7e100883947123f8263c5f06e6c0ea3eb972f


### PR DESCRIPTION
`KAKIBOT_KEY` was an organization secret of `kakiorg`. These repos now live under the personal `cossio` account, where org secrets do not apply, so it expands to an empty string and the step fails outright:

```
ssh-add - <<< ""
Error loading key "(stdin)": error in libcrypto
```

That step existed only to clone **private** dependencies during package resolution. Those are being vendored in-repo, so no SSH auth is needed — public deps still resolve over https from the public registry, and the `Pkg.Registry.add` step is untouched.

Changed: `ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gJC9rUC6ERVq4sqT1yP56